### PR TITLE
Fix date handling for the result of shiftDetection for dates < 1970

### DIFF
--- a/src/main/java/org/baratinage/ui/baratin/rating_shifts_happens/gaugings/ShiftDetectionResults.java
+++ b/src/main/java/org/baratinage/ui/baratin/rating_shifts_happens/gaugings/ShiftDetectionResults.java
@@ -155,7 +155,7 @@ public class ShiftDetectionResults {
       endShift = shifts.get(k);
       GaugingsDataset dataset = buildGaugingDataset(
           time, stage, discharge, dischargeStd,
-          startShift == null ? 0 : startShift.parameter().getMaxpost(),
+          startShift == null ? - Double.MAX_VALUE : startShift.parameter().getMaxpost(),
           endShift.parameter().getMaxpost());
       Color color = getColor(k);
       periods.add(buildResultPeriod(dataset, startShift, endShift, color));
@@ -163,7 +163,7 @@ public class ShiftDetectionResults {
     }
     GaugingsDataset dataset = buildGaugingDataset(
         time, stage, discharge, dischargeStd,
-        startShift == null ? 0 : startShift.parameter().getMaxpost(),
+        startShift == null ?  - Double.MAX_VALUE : startShift.parameter().getMaxpost(),
         Double.MAX_VALUE);
     Color color = getColor(shifts.size());
     periods.add(buildResultPeriod(dataset, startShift, null, color));
@@ -246,12 +246,12 @@ public class ShiftDetectionResults {
     String endTimeString = endTime == Double.MAX_VALUE
         ? dateFormatter.format(DateTime.doubleToDateTime(time[time.length - 1]))
         : dateFormatter.format(DateTime.doubleToDateTime(endTime));
-    String startTimeString = startTime == 0.0
+    String startTimeString = startTime == - Double.MAX_VALUE
         ? dateFormatter.format(DateTime.doubleToDateTime(time[0]))
         : dateFormatter.format(DateTime.doubleToDateTime(startTime));
-    if ((startTime == 0 && endTime == Double.MAX_VALUE) || (startTime != 0 && endTime != Double.MAX_VALUE)) {
+    if ((startTime == - Double.MAX_VALUE && endTime == Double.MAX_VALUE) || (startTime !=  - Double.MAX_VALUE  && endTime != Double.MAX_VALUE)) {
       name = String.format("%s - %s", startTimeString, endTimeString);
-    } else if (startTime == 0) {
+    } else if (startTime == - Double.MAX_VALUE) {
       name = String.format("< %s", dateFormatter.format(DateTime.doubleToDateTime(endTime)));
     } else if (endTime == Double.MAX_VALUE) {
       name = String.format("> %s", dateFormatter.format(DateTime.doubleToDateTime(startTime)));


### PR DESCRIPTION
Added the porper handling for dates prior to 1970

The date limit was priorly limited to a zero value (or in other term 1970)

This now allows to the startShift to be negative and therefore prior to 1970.