### PR TITLE
GitHub Action to automate the build process on Windows and Linux and Make a pre-release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -159,11 +159,11 @@ jobs:
           with:
             path: artifacts
 
-        - name: Unzip Artifacts
-          run: |
-            mkdir -p release_content
-            # Find all zip files and unzip them into release_content
-            find artifacts -name "*.zip" -exec unzip {} -d release_content \;
+        # - name: Unzip Artifacts
+        #   run: |
+        #     mkdir -p release_content
+        #     # Find all zip files and unzip them into release_content
+        #     find artifacts -name "*.zip" -exec unzip {} -d release_content \;
 
         - name: Create Release
           uses: softprops/action-gh-release@v1
@@ -172,7 +172,7 @@ jobs:
             name: BaRatinAGE ${{ env.VERSION_FULL }}
             generate_release_notes: true
             files: |
-              release_content/**/*
+              artifacts/**/*
             prerelease: true
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a github action  to automate the build process on Windows and Linux and Make a pre-release. It has the following features:
- it is triggered only manually
- it required one argument which must be a string in the form `x.x.x` corresponding to the version of the build
- it also has an additional optional argument which must be either empty or a single digit `y` to indicate the beta version number; if specified the full build version will be `x.x.x-beta-y`
- it performs the following steps:
  - it build the jar file
  - it package the app into a standalone executable (jpackage)
  - it downloads the BaM and distribution CLI executables to add them to the resulting packaged app
  - it download any example project file (.bam files) to include; these files are downloaded from a  pre-release in the current repo with the name `examples-vx` where `x` indicate the pre-release version for the example files
  - it creates a pre-release with the resulting build files and the tag corresponding to the version of the build ( `x.x.x` or  `x.x.x-beta-y`)