### PR TITLE
Improved github action to build and release BaRatinAGE

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,4 +1,4 @@
-name: Build App
+name: Build And Realease BaRatinAGE
 
 on:
   workflow_dispatch:
@@ -8,19 +8,41 @@ on:
         required: true
       beta-version:
         description: "A single digit indicating the beta version number (e.g. 6)"
+      draft-release:
+        description: "Should a release be drafted?"
+        required: true
+        default: 'true'
+        type: boolean
 
 jobs:
+
+  inputs_processing:
+    name: Process inputs
+    runs-on: ubuntu-latest
+
+    outputs:
+      VERSION_FULL: ${{ steps.derived.outputs.VERSION_FULL }}
+      IS_BETA: ${{ steps.derived.outputs.IS_BETA }}
+
+    steps:
+      - name: Derive variables
+        id: derived
+        shell: pwsh
+        run: |
+          if ("${{ github.event.inputs.beta-version }}" -ne "") {
+            $versionFull = "${{ github.event.inputs.version }}-Beta-${{ github.event.inputs.beta-version }}"
+            $isBeta = $true
+          } else {
+            $versionFull = "${{ github.event.inputs.version }}"
+            $isBeta = $false
+          }
+          echo "VERSION_FULL=$versionFull" >> $env:GITHUB_OUTPUT
+          echo "IS_BETA=$isBeta" >> $env:GITHUB_OUTPUT
+
   build:
-
-    env:
-      EXT_EXE_DIR: exe
-      EXAMPLES_DIR: example
-      DIRS_TO_CREATE: "log exe/bam_workspace"
-      DIRS_TO_COPY: "resources/fonts resources/i18n resources/icons example"
-      FILES_TO_COPY: "resources/credits.csv resources/baratin_qfh_presets.json"
-      VERSION: ${{ github.event.inputs.version }}
-
+    needs: [inputs_processing]
     runs-on:  ${{ matrix.os }}
+
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
@@ -32,16 +54,16 @@ jobs:
             ICON_PATH: resources/icons/icon.png
             MAIN_DIR: out/BaRatinAGE/bin
 
+    env:
+      EXT_EXE_DIR: exe
+      EXAMPLES_DIR: example
+      DIRS_TO_CREATE: "log exe/bam_workspace"
+      DIRS_TO_COPY: "resources/fonts resources/i18n resources/icons example"
+      FILES_TO_COPY: "resources/credits.csv resources/baratin_qfh_presets.json"
+      VERSION: ${{ github.event.inputs.version }}
+      VERSION_FULL: ${{ needs.inputs_processing.outputs.VERSION_FULL }}
+
     steps:
-      - name: Derive other environment variables
-        shell: pwsh
-        run: |
-          if ("${{ github.event.inputs.beta-version }}") {
-            $versionFull = "${{ github.event.inputs.version }}-Beta-${{ github.event.inputs.beta-version }}"
-          } else {
-            $versionFull = "${{ github.event.inputs.version }}"
-          }
-          echo "VERSION_FULL=$versionFull" >> $env:GITHUB_ENV
 
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -125,31 +147,36 @@ jobs:
           $zipPath = Get-ChildItem -Filter "distribution-*_${{ runner.OS }}.zip" | Select-Object -First 1
           Expand-Archive $zipPath.FullName -DestinationPath (Join-Path "${{ matrix.MAIN_DIR }}" "${{ env.EXT_EXE_DIR }}") -Force
 
+      - name: Rename main directory
+        shell: pwsh
+        run: >
+          Rename-Item
+          -Path out/BaRatinAGE 
+          -NewName "BaRatinAGE-${{ env.VERSION_FULL }}"
+      
       - name: Zip packaged app
         shell: pwsh
-        run: |
-          $zipFile = "BaRatinAGE-${{ env.VERSION_FULL }}_${{ runner.OS }}.zip"
-          Compress-Archive -Path out/BaRatinAGE -DestinationPath $zipFile -Force
+        run: >
+          Compress-Archive 
+          -Path "out/BaRatinAGE-${{ env.VERSION_FULL }}" 
+          -DestinationPath "BaRatinAGE-${{ env.VERSION_FULL }}_${{ runner.OS }}.zip" 
+          -Force
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: BaRatinAGE-${{ env.VERSION_FULL }}_${{ runner.OS }}
-          path: BaRatinAGE-${{ env.VERSION }}_${{ runner.OS }}.zip
+          path: BaRatinAGE-${{ env.VERSION_FULL }}_${{ runner.OS }}.zip
 
   create_release:
-      needs: [build]
+      if: ${{ github.event.inputs.draft-release == 'true' }}
+      needs: [build, inputs_processing]
       runs-on: ubuntu-latest
+
+      env:
+        VERSION_FULL: ${{ needs.inputs_processing.outputs.VERSION_FULL }}
+        IS_BETA:  ${{ needs.inputs_processing.outputs.IS_BETA == 'True'}}
       steps:
-        - name: Derive other environment variables
-          shell: pwsh
-          run: |
-            if ("${{ github.event.inputs.beta-version }}") {
-              $versionFull = "${{ github.event.inputs.version }}-Beta-${{ github.event.inputs.beta-version }}"
-            } else {
-              $versionFull = "${{ github.event.inputs.version }}"
-            }
-            echo "VERSION_FULL=$versionFull" >> $env:GITHUB_ENV
 
         - name: Checkout code
           uses: actions/checkout@v4
@@ -159,20 +186,15 @@ jobs:
           with:
             path: artifacts
 
-        # - name: Unzip Artifacts
-        #   run: |
-        #     mkdir -p release_content
-        #     # Find all zip files and unzip them into release_content
-        #     find artifacts -name "*.zip" -exec unzip {} -d release_content \;
-
         - name: Create Release
-          uses: softprops/action-gh-release@v1
+          uses: softprops/action-gh-release@v2
           with:
             tag_name: ${{ env.VERSION_FULL }}
             name: BaRatinAGE ${{ env.VERSION_FULL }}
             generate_release_notes: true
             files: |
               artifacts/**/*
-            prerelease: true
+            prerelease: ${{ env.IS_BETA }}
+            draft: true
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR includes an updated version of the GitHub action that automates the build and release process of BaRatinAGE. The main changes are:
- rename the main folder contained in the zip file to include the version number
- new option to skip creating a release (only builds BaRatinAGE)
- release is now a draft
- drafted release is either marked as latest or pre-release depending on whether it is a beta version or not
- better overall structure